### PR TITLE
Colorize user roles and make emails clickable

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
 
   http: ^1.5.0
   provider: ^6.1.2
+  url_launcher: ^6.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds coloring to user roles (admin=red, user=green, other=yellow) and makes emails clickable to open the device's email client with the address prefilled.