### PR TITLE
Colorize roles and make emails clickable

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
 
   http: ^1.5.0
   provider: ^6.1.2
+  url_launcher: ^6.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds colorization to user roles in the user list: red for admin, green for user, yellow for other. Also makes emails clickable to open the device's email client with the address prefilled. Added url_launcher dependency.