### PR TITLE
Colorize roles and make emails clickable

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter/gestures.dart';
 
 import 'theme_notifier.dart';
 import 'settings_screen.dart';
@@ -59,6 +61,12 @@ class _MyHomePageState extends State<MyHomePage> {
   late TextEditingController _searchController;
   Set<int> _selectedUserIds = {};
 
+  Color _getRoleColor(String role) {
+    if (role == 'admin') return Colors.red;
+    if (role == 'user') return Colors.green;
+    return Colors.yellow;
+  }
+
   @override
   void initState() {
     super.initState();
@@ -114,8 +122,8 @@ class _MyHomePageState extends State<MyHomePage> {
     } catch (e) {
       setState(() {
         _users = [];
-        _displayedUsers = [];
-      });
+          _displayedUsers = [];
+        }
     }
   }
 
@@ -430,7 +438,35 @@ class _MyHomePageState extends State<MyHomePage> {
                     ? const TextStyle(fontWeight: FontWeight.bold)
                     : null,
               ),
-              subtitle: Text('Role: ${_displayedUsers[index]['role']}, Email: ${_displayedUsers[index]['email']}'),
+              subtitle: RichText(
+                text: TextSpan(
+                  style: Theme.of(context).textTheme.bodyMedium,
+                  children: [
+                    const TextSpan(text: 'Role: '),
+                    TextSpan(
+                      text: _displayedUsers[index]['role'],
+                      style: TextStyle(color: _getRoleColor(_displayedUsers[index]['role'])),
+                    ),
+                    const TextSpan(text: ', Email: '),
+                    TextSpan(
+                      text: _displayedUsers[index]['email'],
+                      style: const TextStyle(color: Colors.blue, decoration: TextDecoration.underline),
+                      recognizer: TapGestureRecognizer()
+                        ..onTap = () async {
+                          final email = _displayedUsers[index]['email'];
+                          final url = Uri.parse('mailto:$email');
+                          if (await canLaunchUrl(url)) {
+                            await launchUrl(url);
+                          } else {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('Could not launch email client')),
+                            );
+                          }
+                        },
+                    ),
+                  ],
+                ),
+              ),
               trailing: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
 
   http: ^1.5.0
   provider: ^6.1.2
+  url_launcher: ^6.2.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR implements the requested features: colorizing user roles (admin=red, user=green, other=yellow) and making emails clickable to open the device email client with the address prefilled.