### PR TITLE
Colorize user roles and make emails clickable

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,9 +3,21 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'theme_notifier.dart';
 import 'settings_screen.dart';
+
+Color getRoleColor(String role) {
+  switch (role.toLowerCase()) {
+    case 'admin':
+      return Colors.red;
+    case 'user':
+      return Colors.green;
+    default:
+      return Colors.yellow;
+  }
+}
 
 void main() {
   runApp(
@@ -430,7 +442,32 @@ class _MyHomePageState extends State<MyHomePage> {
                     ? const TextStyle(fontWeight: FontWeight.bold)
                     : null,
               ),
-              subtitle: Text('Role: ${_displayedUsers[index]['role']}, Email: ${_displayedUsers[index]['email']}'),
+              subtitle: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Role: ${_displayedUsers[index]['role']}',
+                    style: TextStyle(color: getRoleColor(_displayedUsers[index]['role'])),
+                  ),
+                  InkWell(
+                    onTap: () async {
+                      final email = _displayedUsers[index]['email'];
+                      final uri = Uri(scheme: 'mailto', path: email);
+                      if (await canLaunchUrl(uri)) {
+                        await launchUrl(uri);
+                      } else {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text('Cannot open email client for $email')),
+                        );
+                      }
+                    },
+                    child: Text(
+                      'Email: ${_displayedUsers[index]['email']}',
+                      style: TextStyle(color: Colors.blue, decoration: TextDecoration.underline),
+                    ),
+                  ),
+                ],
+              ),
               trailing: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
 
   http: ^1.5.0
   provider: ^6.1.2
+  url_launcher: ^6.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds color coding to user roles (admin=red, user=green, other=yellow) and makes email addresses clickable to open the device's email client.