### PR TITLE
Colorize user roles and make emails clickable

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'theme_notifier.dart';
 import 'settings_screen.dart';
@@ -430,7 +431,38 @@ class _MyHomePageState extends State<MyHomePage> {
                     ? const TextStyle(fontWeight: FontWeight.bold)
                     : null,
               ),
-              subtitle: Text('Role: ${_displayedUsers[index]['role']}, Email: ${_displayedUsers[index]['email']}'),
+              subtitle: Row(
+                children: [
+                  const Text('Role: '),
+                  Text(
+                    _displayedUsers[index]['role'],
+                    style: TextStyle(
+                      color: _displayedUsers[index]['role'] == 'admin' ? Colors.red : _displayedUsers[index]['role'] == 'user' ? Colors.green : Colors.yellow,
+                    ),
+                  ),
+                  const Text(', Email: '),
+                  InkWell(
+                    onTap: () async {
+                      final email = _displayedUsers[index]['email'];
+                      final Uri emailUri = Uri(scheme: 'mailto', path: email);
+                      try {
+                        await launchUrl(emailUri);
+                      } catch (e) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text('Cannot open email client: $e')),
+                        );
+                      }
+                    },
+                    child: Text(
+                      _displayedUsers[index]['email'],
+                      style: const TextStyle(
+                        color: Colors.blue,
+                        decoration: TextDecoration.underline,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
               trailing: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
 
   http: ^1.5.0
   provider: ^6.1.2
+  url_launcher: ^6.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds coloring to user roles (admin=red, user=green, other=yellow) and makes emails clickable to open the device's email client using url_launcher package.