### PR TITLE
Make theme toggle tile fully clickable

### DIFF
--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -15,16 +15,17 @@ class SettingsScreen extends StatelessWidget {
       ),
       body: ListView(
         children: [
-          ListTile(
-            title: const Text('Dark Theme'),
-            trailing: Consumer<ThemeNotifier>(
-              builder: (context, themeNotifier, child) {
-                return ThemeToggle(
+          Consumer<ThemeNotifier>(
+            builder: (context, themeNotifier, child) {
+              return ListTile(
+                title: const Text('Dark Theme'),
+                onTap: () => themeNotifier.toggleTheme(themeNotifier.themeMode != ThemeMode.dark),
+                trailing: ThemeToggle(
                   isDark: themeNotifier.themeMode == ThemeMode.dark,
                   onToggle: themeNotifier.toggleTheme,
-                );
-              },
-            ),
+                ),
+              );
+            },
           ),
         ],
       ),


### PR DESCRIPTION
This PR makes the entire theme toggle tile in the settings screen clickable, not just the switch widget. Users can now tap anywhere on the tile to toggle the theme, improving usability.