### PR TITLE
Make the entire theme tile clickable to toggle theme

### DIFF
--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -15,16 +15,17 @@ class SettingsScreen extends StatelessWidget {
       ),
       body: ListView(
         children: [
-          ListTile(
-            title: const Text('Dark Theme'),
-            trailing: Consumer<ThemeNotifier>(
-              builder: (context, themeNotifier, child) {
-                return ThemeToggle(
+          Consumer<ThemeNotifier>(
+            builder: (context, themeNotifier, child) {
+              return ListTile(
+                title: const Text('Dark Theme'),
+                onTap: () => themeNotifier.toggleTheme(),
+                trailing: ThemeToggle(
                   isDark: themeNotifier.themeMode == ThemeMode.dark,
                   onToggle: themeNotifier.toggleTheme,
-                );
-              },
-            ),
+                ),
+              );
+            },
           ),
         ],
       ),


### PR DESCRIPTION
This PR addresses the issue where only the switch in the theme toggle was clickable. Now, the entire 'Dark Theme' tile in the settings screen is clickable, improving UX by allowing users to tap anywhere on the tile to toggle the theme.

Changes:
- Added `onTap` callback to the `ListTile` in `lib/settings_screen.dart` that calls `themeNotifier.toggleTheme()`.

This maintains the existing functionality while expanding the clickable area.