### PR TITLE
Make Theme Tile Fully Clickable

### DIFF
--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -15,16 +15,17 @@ class SettingsScreen extends StatelessWidget {
       ),
       body: ListView(
         children: [
-          ListTile(
-            title: const Text('Dark Theme'),
-            trailing: Consumer<ThemeNotifier>(
-              builder: (context, themeNotifier, child) {
-                return ThemeToggle(
+          Consumer<ThemeNotifier>(
+            builder: (context, themeNotifier, child) {
+              return ListTile(
+                title: const Text('Dark Theme'),
+                onTap: () => themeNotifier.toggleTheme(themeNotifier.themeMode != ThemeMode.dark),
+                trailing: ThemeToggle(
                   isDark: themeNotifier.themeMode == ThemeMode.dark,
                   onToggle: themeNotifier.toggleTheme,
-                );
-              },
-            ),
+                ),
+              );
+            },
           ),
         ],
       ),


### PR DESCRIPTION
This PR updates the settings screen to make the entire theme tile clickable. Previously, only the custom switch was interactive; now, tapping anywhere on the tile (including the title area) will toggle the theme. The change maintains the existing toggle switch for visual feedback and direct interaction.