### PR TITLE
Make entire theme tile clickable in settings screen

### DIFF
--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -15,16 +15,16 @@ class SettingsScreen extends StatelessWidget {
       ),
       body: ListView(
         children: [
-          ListTile(
-            title: const Text('Dark Theme'),
-            trailing: Consumer<ThemeNotifier>(
-              builder: (context, themeNotifier, child) {
-                return ThemeToggle(
+          Consumer<ThemeNotifier>(
+            builder: (context, themeNotifier, child) {
+              return ListTile(
+                title: const Text('Dark Theme'),
+                onTap: () => themeNotifier.toggleTheme(themeNotifier.themeMode == ThemeMode.light),
+                trailing: ThemeToggle(
                   isDark: themeNotifier.themeMode == ThemeMode.dark,
-                  onToggle: themeNotifier.toggleTheme,
-                );
-              },
-            ),
+                ),
+              );
+            },
           ),
         ],
       ),

--- a/lib/theme_toggle.dart
+++ b/lib/theme_toggle.dart
@@ -1,94 +1,66 @@
 import 'package:flutter/material.dart';
 
-class ThemeToggle extends StatefulWidget {
+class ThemeToggle extends StatelessWidget {
   final bool isDark;
-  final Function(bool) onToggle;
 
   const ThemeToggle({
     super.key,
     required this.isDark,
-    required this.onToggle,
   });
 
   @override
-  State<ThemeToggle> createState() => _ThemeToggleState();
-}
-
-class _ThemeToggleState extends State<ThemeToggle> {
-  late bool _isDark;
-
-  @override
-  void initState() {
-    super.initState();
-    _isDark = widget.isDark;
-  }
-
-  @override
-  void didUpdateWidget(covariant ThemeToggle oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    _isDark = widget.isDark;
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        _isDark = !_isDark;
-        widget.onToggle(_isDark);
-        setState(() {});
-      },
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        width: 70,
-        height: 34,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(20),
-          color: _isDark ? Colors.grey[800] : Colors.yellow[100],
-        ),
-        child: Stack(
-          children: [
-            AnimatedPositioned(
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      width: 70,
+      height: 34,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        color: isDark ? Colors.grey[800] : Colors.yellow[100],
+      ),
+      child: Stack(
+        children: [
+          AnimatedPositioned(
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeInOut,
+            top: 4,
+            left: isDark ? 36 : 4,
+            child: Container(
+              width: 26,
+              height: 26,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.white,
+              ),
+            ),
+          ),
+          Positioned(
+            left: 5,
+            top: 5,
+            child: AnimatedOpacity(
               duration: const Duration(milliseconds: 200),
-              curve: Curves.easeInOut,
-              top: 4,
-              left: _isDark ? 36 : 4,
-              child: Container(
-                width: 26,
-                height: 26,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: Colors.white,
-                ),
+              opacity: isDark ? 0.5 : 1.0,
+              child: const Icon(
+                Icons.wb_sunny,
+                color: Colors.orange,
+                size: 24,
               ),
             ),
-            Positioned(
-              left: 5,
-              top: 5,
-              child: AnimatedOpacity(
-                duration: const Duration(milliseconds: 200),
-                opacity: _isDark ? 0.5 : 1.0,
-                child: const Icon(
-                  Icons.wb_sunny,
-                  color: Colors.orange,
-                  size: 24,
-                ),
+          ),
+          Positioned(
+            right: 5,
+            top: 5,
+            child: AnimatedOpacity(
+              duration: const Duration(milliseconds: 200),
+              opacity: isDark ? 1.0 : 0.5,
+              child: const Icon(
+                Icons.nightlight_round,
+                color: Colors.blueGrey,
+                size: 24,
               ),
             ),
-            Positioned(
-              right: 5,
-              top: 5,
-              child: AnimatedOpacity(
-                duration: const Duration(milliseconds: 200),
-                opacity: _isDark ? 1.0 : 0.5,
-                child: const Icon(
-                  Icons.nightlight_round,
-                  color: Colors.blueGrey,
-                  size: 24,
-                ),
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
Updated the settings screen to allow tapping on the entire 'Dark Theme' tile to toggle the theme, not just the switch. Modified ThemeToggle to be stateless and removed tap handling to avoid gesture conflicts.