### PR TITLE
Make theme toggle tile fully clickable

### DIFF
--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -17,6 +17,10 @@ class SettingsScreen extends StatelessWidget {
         children: [
           ListTile(
             title: const Text('Dark Theme'),
+            onTap: () {
+              final themeNotifier = Provider.of<ThemeNotifier>(context, listen: false);
+              themeNotifier.toggleTheme(themeNotifier.themeMode != ThemeMode.dark);
+            },
             trailing: Consumer<ThemeNotifier>(
               builder: (context, themeNotifier, child) {
                 return ThemeToggle(

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -54,4 +54,22 @@ void main() {
     expect(find.text('Settings'), findsOneWidget);
     expect(find.text('Dark Theme'), findsOneWidget);
   });
+
+  testWidgets('Tapping dark theme tile toggles theme', (WidgetTester tester) async {
+    final themeNotifier = ThemeNotifier();
+    await tester.pumpWidget(ChangeNotifierProvider(
+      create: (_) => themeNotifier,
+      child: const MyApp(),
+    ));
+
+    await tester.tap(find.byIcon(Icons.settings));
+    await tester.pumpAndSettle();
+
+    expect(themeNotifier.themeMode, ThemeMode.light);
+
+    await tester.tap(find.text('Dark Theme'));
+    await tester.pump();
+
+    expect(themeNotifier.themeMode, ThemeMode.dark);
+  });
 }


### PR DESCRIPTION
This PR updates the settings screen to make the entire 'Dark Theme' tile clickable for toggling the theme, not just the switch widget. This improves user experience by providing a larger tap target.

Changes:
- Added onTap handler to the ListTile in SettingsScreen that toggles the theme.
- Added a test case to verify the tile tap functionality.

The existing ThemeToggle widget remains clickable as well, ensuring compatibility.