### PR TITLE
Make theme toggle tile fully clickable

### DIFF
--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -17,6 +17,9 @@ class SettingsScreen extends StatelessWidget {
         children: [
           ListTile(
             title: const Text('Dark Theme'),
+            onTap: () {
+              Provider.of<ThemeNotifier>(context, listen: false).toggleTheme();
+            },
             trailing: Consumer<ThemeNotifier>(
               builder: (context, themeNotifier, child) {
                 return ThemeToggle(


### PR DESCRIPTION
This PR updates the settings screen to make the entire theme toggle tile clickable for switching themes, instead of only the switch component. This improves user experience by allowing taps anywhere on the tile.

Changes:
- Added onTap handler to the ListTile in `lib/settings_screen.dart` that triggers the theme toggle.
- No changes to the ThemeToggle widget or other parts of the app.