### PR TITLE
Make entire theme toggle tile clickable

### DIFF
--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -15,16 +15,20 @@ class SettingsScreen extends StatelessWidget {
       ),
       body: ListView(
         children: [
-          ListTile(
-            title: const Text('Dark Theme'),
-            trailing: Consumer<ThemeNotifier>(
-              builder: (context, themeNotifier, child) {
-                return ThemeToggle(
+          Consumer<ThemeNotifier>(
+            builder: (context, themeNotifier, child) {
+              return ListTile(
+                title: const Text('Dark Theme'),
+                trailing: ThemeToggle(
                   isDark: themeNotifier.themeMode == ThemeMode.dark,
                   onToggle: themeNotifier.toggleTheme,
-                );
-              },
-            ),
+                ),
+                onTap: () {
+                  final newIsDark = !(themeNotifier.themeMode == ThemeMode.dark);
+                  themeNotifier.toggleTheme(newIsDark);
+                },
+              );
+            },
           ),
         ],
       ),

--- a/lib/theme_toggle.dart
+++ b/lib/theme_toggle.dart
@@ -31,64 +31,57 @@ class _ThemeToggleState extends State<ThemeToggle> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        _isDark = !_isDark;
-        widget.onToggle(_isDark);
-        setState(() {});
-      },
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        width: 70,
-        height: 34,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(20),
-          color: _isDark ? Colors.grey[800] : Colors.yellow[100],
-        ),
-        child: Stack(
-          children: [
-            AnimatedPositioned(
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      width: 70,
+      height: 34,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        color: _isDark ? Colors.grey[800] : Colors.yellow[100],
+      ),
+      child: Stack(
+        children: [
+          AnimatedPositioned(
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeInOut,
+            top: 4,
+            left: _isDark ? 36 : 4,
+            child: Container(
+              width: 26,
+              height: 26,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.white,
+              ),
+            ),
+          ),
+          Positioned(
+            left: 5,
+            top: 5,
+            child: AnimatedOpacity(
               duration: const Duration(milliseconds: 200),
-              curve: Curves.easeInOut,
-              top: 4,
-              left: _isDark ? 36 : 4,
-              child: Container(
-                width: 26,
-                height: 26,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: Colors.white,
-                ),
+              opacity: _isDark ? 0.5 : 1.0,
+              child: const Icon(
+                Icons.wb_sunny,
+                color: Colors.orange,
+                size: 24,
               ),
             ),
-            Positioned(
-              left: 5,
-              top: 5,
-              child: AnimatedOpacity(
-                duration: const Duration(milliseconds: 200),
-                opacity: _isDark ? 0.5 : 1.0,
-                child: const Icon(
-                  Icons.wb_sunny,
-                  color: Colors.orange,
-                  size: 24,
-                ),
+          ),
+          Positioned(
+            right: 5,
+            top: 5,
+            child: AnimatedOpacity(
+              duration: const Duration(milliseconds: 200),
+              opacity: _isDark ? 1.0 : 0.5,
+              child: const Icon(
+                Icons.nightlight_round,
+                color: Colors.blueGrey,
+                size: 24,
               ),
             ),
-            Positioned(
-              right: 5,
-              top: 5,
-              child: AnimatedOpacity(
-                duration: const Duration(milliseconds: 200),
-                opacity: _isDark ? 1.0 : 0.5,
-                child: const Icon(
-                  Icons.nightlight_round,
-                  color: Colors.blueGrey,
-                  size: 24,
-                ),
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
This PR updates the settings screen to make the entire 'Dark Theme' tile clickable for toggling the theme, not just the switch widget. Changes include adding an onTap handler to the ListTile and removing the GestureDetector from ThemeToggle to prevent conflicts.