### PR TITLE
Fix(UI): Correct widget nesting and theme definition

### DIFF
--- a/lib/app_config/app_theme.dart
+++ b/lib/app_config/app_theme.dart
@@ -65,7 +65,7 @@ class AppTheme {
     ),
     
     // Card Theme
-    cardTheme: CardTheme(
+    cardTheme: CardThemeData(
       elevation: 0,
       color: _lightSurface,
       shape: RoundedRectangleBorder(
@@ -229,7 +229,7 @@ class AppTheme {
     ),
     
     // Card Theme
-    cardTheme: CardTheme(
+    cardTheme: CardThemeData(
       elevation: 0,
       color: _darkSurface,
       shape: RoundedRectangleBorder(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -480,7 +480,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
               ),
             ),
-          ],
+          ),
         ],
       ),
       floatingActionButton: FloatingActionButton.extended(


### PR DESCRIPTION
- Fix `CardTheme` constructor calls by using `CardThemeData`.
- Correct widget structure in `main.dart` by removing a misplaced parenthesis.