### PR TITLE
Fix missing settings button in main screen app bar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -322,6 +322,20 @@ class _MyHomePageState extends State<MyHomePage> {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            tooltip: 'Settings',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const SettingsScreen(),
+                ),
+              );
+            },
+          ),
+        ],
       ),
       body: ListView(
         padding: EdgeInsets.all(16.0),


### PR DESCRIPTION
The settings button was missing from the AppBar in the main screen. This PR adds an IconButton with the settings icon that navigates to the SettingsScreen, allowing users to access theme settings and other configurations.

## Changes Made
- Modified `lib/main.dart` to add `actions` to the `AppBar` in the main screen.
- Added an `IconButton` with `Icons.settings` icon and tooltip 'Settings'.
- The button navigates to the `SettingsScreen` using `Navigator.push`.

## Testing
- The button appears in the AppBar on the right side.
- Tapping the button navigates to the settings screen.
- The settings screen has the theme toggle as expected.

## UI/UX
- Follows Material Design guidelines for app bar actions.
- Icon is standard settings gear.
- Includes tooltip for accessibility.