### PR TITLE
Soften the light theme background to reduce glare

### DIFF
--- a/lib/app_config/app_theme.dart
+++ b/lib/app_config/app_theme.dart
@@ -8,11 +8,11 @@ class AppTheme {
   static const Color _lightPrimary = Color(0xFF2563EB);
   static const Color _lightPrimaryVariant = Color(0xFF1D4ED8);
   static const Color _lightSecondary = Color(0xFF64748B);
-  static const Color _lightBackground = Color(0xFFF8FAFC);
+  static const Color _lightBackground = Color(0xFFF8F9FA);
   static const Color _lightSurface = Color(0xFFFFFFFF);
   static const Color _lightError = Color(0xFFDC2626);
   static const Color _lightOnPrimary = Color(0xFFFFFFFF);
-  static const Color _lightOnBackground = Color(0xFF1E293B);
+  static const Color _lightOnBackground = Color(0xFF1F2937);
   static const Color _lightOnSurface = Color(0xFF334155);
   static const Color _lightOnSurfaceVariant = Color(0xFF64748B);
 
@@ -54,7 +54,7 @@ class AppTheme {
     appBarTheme: const AppBarTheme(
       elevation: 0,
       centerTitle: true,
-      backgroundColor: _lightSurface,
+      backgroundColor: _lightBackground,
       foregroundColor: _lightOnBackground,
       surfaceTintColor: Colors.transparent,
       titleTextStyle: TextStyle(
@@ -317,9 +317,9 @@ class AppTheme {
           );
         }
         return const TextStyle(
-          color: _darkOnSurfaceVariant,
-          fontSize: 12,
-        );
+            color: _darkOnSurfaceVariant,
+            fontSize: 12,
+          );
       }),
     ),
     


### PR DESCRIPTION
This PR softens the light theme by changing the scaffold and app bar background to a subtle off-white color (#F8F9FA) instead of pure white, reducing eye strain while maintaining a clean and professional appearance. Surfaces like cards remain white for proper contrast.

Changes:
- Updated _lightBackground to Color(0xFFF8F9FA)
- Changed appBar backgroundColor to _lightBackground for consistency
- Adjusted _lightOnBackground to Color(0xFF1F2937) for better readability

No tests were added as this is a visual theme change, but the existing theme tests should cover it.