### PR TITLE
Update frontend to use backend proxy for loading user avatars

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -327,7 +327,7 @@ class _MyHomePageState extends State<MyHomePage> {
         return UserCard(
           name: userName,
           location: userEmail,
-          avatarUrl: '${Constants.webServiceBaseUrl}/api/proxy?url=${base64Encode('https://i.pravatar.cc/150?img=$userId')}',
+          avatarUrl: '${Constants.webServiceBaseUrl}/api/proxy?url=${base64Encode(utf8.encode('https://i.pravatar.cc/150?img=$userId'))}',
           tags: [userRole],
           isSelected: _selectedUserIds.contains(userId),
           onTap: () {


### PR DESCRIPTION
This PR updates the avatar URL in the UserCard to use the new backend proxy endpoint, ensuring CORS-compliant loading of 3rd party images on web deployment.