### PR TITLE
Add LinkedIn button to user profile cards

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -241,6 +241,7 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
     final roleController = TextEditingController(text: (user?.role ?? ''));
     final emailController = TextEditingController(text: (user?.email ?? ''));
     final phoneController = TextEditingController(text: (user?.phoneNumber ?? ''));
+    final linkedinController = TextEditingController(text: (user?.linkedinUrl ?? ''));
     String gender = (user?.gender ?? 'male');
     final isEdit = user != null;
     final formKey = GlobalKey<FormState>();
@@ -283,10 +284,22 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
                     decoration: const InputDecoration(labelText: 'Phone Number (E.164)', prefixIcon: Icon(Icons.phone), hintText: '+1234567890'),
                     validator: (value) {
                       if (value == null || value.trim().isEmpty) return null;
-                      final cleaned = value.replaceAll(RegExp(r'[\s\-\(\)\[\]]'), '');
+                      final cleaned = value.replaceAll(RegExp(r'[]\s\-\(\)\[\]]'), '');
                       final regex = RegExp(r'^\+?[1-9]\d{6,14}$');
                       if (!regex.hasMatch(cleaned)) {
                         return 'Invalid phone format';
+                      }
+                      return null;
+                    },
+                  ),
+                  TextFormField(
+                    controller: linkedinController,
+                    decoration: const InputDecoration(labelText: 'LinkedIn URL', prefixIcon: Icon(Icons.link)),
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) return null;
+                      final uri = Uri.tryParse(value.trim());
+                      if (uri == null || !uri.hasScheme || !uri.hasAuthority) {
+                        return 'Invalid URL';
                       }
                       return null;
                     },
@@ -327,8 +340,9 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
       final role = roleController.text.trim();
       final email = emailController.text.trim();
       final phoneNumber = phoneController.text.trim().isEmpty ? null : phoneController.text.trim();
+      final linkedinUrl = linkedinController.text.trim().isEmpty ? null : linkedinController.text.trim();
       try {
-        final body = json.encode({'firstName': firstName, 'lastName': lastName, 'role': role, 'email': email, 'phoneNumber': phoneNumber, 'gender': gender});
+        final body = json.encode({'firstName': firstName, 'lastName': lastName, 'role': role, 'email': email, 'phoneNumber': phoneNumber, 'linkedinUrl': linkedinUrl, 'gender': gender});
         final url = isEdit ? '${Constants.webServiceBaseUrl}/api/users/${user!.id}' : '${Constants.webServiceBaseUrl}/api/users';
         final method = isEdit ? http.put : http.post;
         final response = await method(
@@ -373,6 +387,8 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
           gender: user.gender,
           email: user.email,
           phoneNumber: user.phoneNumber,
+          linkedinUrl: user.linkedinUrl,
+          facebookUrl: null,
           isSelected: _selectedUserIds.contains(user.id),
           onTap: () {
             setState(() {

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -13,6 +13,7 @@ class User {
   final String email;
   final String gender;
   final String? phoneNumber;
+  final String? linkedinUrl;
 
   User({
     required this.id,
@@ -22,6 +23,7 @@ class User {
     required this.email,
     required this.gender,
     this.phoneNumber,
+    this.linkedinUrl,
   });
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);

--- a/lib/models/user.g.dart
+++ b/lib/models/user.g.dart
@@ -1,0 +1,23 @@
+part of 'user.dart';
+
+User _$UserFromJson(Map<String, dynamic> json) => User(
+      id: json['id'] as int,
+      firstName: json['firstName'] as String,
+      lastName: json['lastName'] as String,
+      role: json['role'] as String,
+      email: json['email'] as String,
+      gender: json['gender'] as String,
+      phoneNumber: json['phoneNumber'] as String?,
+      linkedinUrl: json['linkedinUrl'] as String?,
+    );
+
+Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
+      'id': instance.id,
+      'firstName': instance.firstName,
+      'lastName': instance.lastName,
+      'role': instance.role,
+      'email': instance.email,
+      'gender': instance.gender,
+      'phoneNumber': instance.phoneNumber,
+      'linkedinUrl': instance.linkedinUrl,
+    };

--- a/lib/user_card.dart
+++ b/lib/user_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class UserCard extends StatelessWidget {
@@ -10,6 +11,7 @@ class UserCard extends StatelessWidget {
   final String gender;
   final String email;
   final String? phoneNumber;
+  final String? linkedinUrl;
   final String? facebookUrl;
   final bool isSelected;
   final VoidCallback? onTap;
@@ -26,6 +28,7 @@ class UserCard extends StatelessWidget {
     required this.gender,
     required this.email,
     this.phoneNumber,
+    this.linkedinUrl,
     this.facebookUrl,
     this.isSelected = false,
     this.onTap,
@@ -112,6 +115,19 @@ class UserCard extends StatelessWidget {
                             onTap: () => _launchUrl('https://wa.me/${phoneNumber!.replaceAll(RegExp(r'[^0-9]'), '')}'),
                           ),
                         ],
+                      ),
+                    ],
+                    // LinkedIn button
+                    if (linkedinUrl != null && linkedinUrl!.isNotEmpty) ...[
+                      const SizedBox(height: 12),
+                      ElevatedButton.icon(
+                        onPressed: () => _launchUrl(linkedinUrl!),
+                        icon: const FaIcon(FontAwesomeIcons.linkedinIn, size: 20),
+                        label: const Text('LinkedIn'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFF0A66C2),
+                          foregroundColor: Colors.white,
+                        ),
                       ),
                     ],
                     // Facebook button

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,7 @@
+---
 name: cool_app_fe
 description: "Coolest app ever made. This is the Flutter frontend of it"
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: 'none'  # Remove this line if you wish to publish to pub.dev
 
 version: 1.0.0+1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   http: ^1.6.0
   provider: ^6.1.5+1
   url_launcher: ^6.3.0
+  font_awesome_flutter: ^10.6.0
 
   # Required for json_serializable
   json_annotation: ^4.9.0


### PR DESCRIPTION
This PR adds a LinkedIn button to the user profile cards. Users can now enter their LinkedIn URL when adding or editing a user, and the button will appear on the card if provided, allowing direct linking to their LinkedIn profile.