### PR TITLE
Add LinkedIn button to profile card and improve input padding

### DIFF
--- a/.trigger-build
+++ b/.trigger-build
@@ -1,0 +1,3 @@
+# Trigger file to run CI/CD pipeline
+# This will run flutter pub get and build_runner build
+# Timestamp: 2024-02-04T13:30:00Z

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -241,6 +241,7 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
     final roleController = TextEditingController(text: (user?.role ?? ''));
     final emailController = TextEditingController(text: (user?.email ?? ''));
     final phoneController = TextEditingController(text: (user?.phoneNumber ?? ''));
+    final linkedinController = TextEditingController(text: (user?.linkedinUrl ?? ''));
     String gender = (user?.gender ?? 'male');
     final isEdit = user != null;
     final formKey = GlobalKey<FormState>();
@@ -260,27 +261,52 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
                 children: [
                   TextFormField(
                     controller: firstNameController,
-                    decoration: const InputDecoration(labelText: 'First Name', prefixIcon: Icon(Icons.person)),
+                    decoration: const InputDecoration(
+                      labelText: 'First Name',
+                      prefixIcon: Icon(Icons.person),
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                    ),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'First name is required' : null,
                   ),
+                  const SizedBox(height: 16),
                   TextFormField(
                     controller: lastNameController,
-                    decoration: const InputDecoration(labelText: 'Last Name', prefixIcon: Icon(Icons.person_outline)),
+                    decoration: const InputDecoration(
+                      labelText: 'Last Name',
+                      prefixIcon: Icon(Icons.person_outline),
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                    ),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Last name is required' : null,
                   ),
+                  const SizedBox(height: 16),
                   TextFormField(
                     controller: roleController,
-                    decoration: const InputDecoration(labelText: 'Role', prefixIcon: Icon(Icons.work)),
+                    decoration: const InputDecoration(
+                      labelText: 'Role',
+                      prefixIcon: Icon(Icons.work),
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                    ),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Role is required' : null,
                   ),
+                  const SizedBox(height: 16),
                   TextFormField(
                     controller: emailController,
-                    decoration: const InputDecoration(labelText: 'Email', prefixIcon: Icon(Icons.email)),
+                    decoration: const InputDecoration(
+                      labelText: 'Email',
+                      prefixIcon: Icon(Icons.email),
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                    ),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Email is required' : null,
                   ),
+                  const SizedBox(height: 16),
                   TextFormField(
                     controller: phoneController,
-                    decoration: const InputDecoration(labelText: 'Phone Number (E.164)', prefixIcon: Icon(Icons.phone), hintText: '+1234567890'),
+                    decoration: const InputDecoration(
+                      labelText: 'Phone Number (E.164)',
+                      prefixIcon: Icon(Icons.phone),
+                      hintText: '+1234567890',
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                    ),
                     validator: (value) {
                       if (value == null || value.trim().isEmpty) return null;
                       final cleaned = value.replaceAll(RegExp(r'[\s\-\(\)\[\]]'), '');
@@ -291,9 +317,36 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
                       return null;
                     },
                   ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: linkedinController,
+                    decoration: const InputDecoration(
+                      labelText: 'LinkedIn URL',
+                      prefixIcon: Icon(Icons.business),
+                      hintText: 'https://www.linkedin.com/in/username',
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                    ),
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) return null;
+                      try {
+                        final uri = Uri.parse(value.trim());
+                        if (!uri.host.contains('linkedin.com')) {
+                          return 'Must be a LinkedIn URL';
+                        }
+                      } catch (e) {
+                        return 'Invalid URL format';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 16),
                   DropdownButtonFormField<String>(
                     value: gender,
-                    decoration: const InputDecoration(labelText: 'Gender', prefixIcon: Icon(Icons.wc)),
+                    decoration: const InputDecoration(
+                      labelText: 'Gender',
+                      prefixIcon: Icon(Icons.wc),
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                    ),
                     items: ['male', 'female'].map((g) => DropdownMenuItem(value: g, child: Text(g[0].toUpperCase() + g.substring(1)))).toList(),
                     onChanged: (value) => setState(() => gender = value!),
                     validator: (value) => value == null ? 'Gender is required' : null,
@@ -327,8 +380,17 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
       final role = roleController.text.trim();
       final email = emailController.text.trim();
       final phoneNumber = phoneController.text.trim().isEmpty ? null : phoneController.text.trim();
+      final linkedinUrl = linkedinController.text.trim().isEmpty ? null : linkedinController.text.trim();
       try {
-        final body = json.encode({'firstName': firstName, 'lastName': lastName, 'role': role, 'email': email, 'phoneNumber': phoneNumber, 'gender': gender});
+        final body = json.encode({
+          'firstName': firstName,
+          'lastName': lastName,
+          'role': role,
+          'email': email,
+          'phoneNumber': phoneNumber,
+          'linkedinUrl': linkedinUrl,
+          'gender': gender,
+        });
         final url = isEdit ? '${Constants.webServiceBaseUrl}/api/users/${user!.id}' : '${Constants.webServiceBaseUrl}/api/users';
         final method = isEdit ? http.put : http.post;
         final response = await method(
@@ -373,6 +435,7 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
           gender: user.gender,
           email: user.email,
           phoneNumber: user.phoneNumber,
+          linkedinUrl: user.linkedinUrl,
           isSelected: _selectedUserIds.contains(user.id),
           onTap: () {
             setState(() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -143,14 +143,18 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
           _selectedUserIds.remove(id);
         });
       } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to delete user')),
-        );
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Failed to delete user')),
+          );
+        }
       }
     } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Error: $e')),
-      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error: $e')),
+        );
+      }
     }
   }
 
@@ -167,14 +171,18 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
           _selectedUserIds.clear();
         });
       } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to delete users')),
-        );
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Failed to delete users')),
+          );
+        }
       }
     } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Error: $e')),
-      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error: $e')),
+        );
+      }
     }
   }
 
@@ -400,18 +408,24 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
         );
         if (response.statusCode == 200 || response.statusCode == 201) {
           await _fetchUsers();
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(isEdit ? 'User updated' : 'User added')),
-          );
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(isEdit ? 'User updated' : 'User added')),
+            );
+          }
         } else {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Failed to save user')),
-          );
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Failed to save user')),
+            );
+          }
         }
       } catch (e) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error: $e')),
-        );
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Error: $e')),
+          );
+        }
       }
     }
   }

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -13,6 +13,7 @@ class User {
   final String email;
   final String gender;
   final String? phoneNumber;
+  final String? linkedinUrl;
 
   User({
     required this.id,
@@ -22,6 +23,7 @@ class User {
     required this.email,
     required this.gender,
     this.phoneNumber,
+    this.linkedinUrl,
   });
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);

--- a/lib/models/user.g.dart
+++ b/lib/models/user.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+User _$UserFromJson(Map<String, dynamic> json) => User(
+      id: (json['id'] as num).toInt(),
+      firstName: json['firstName'] as String,
+      lastName: json['lastName'] as String,
+      role: json['role'] as String,
+      email: json['email'] as String,
+      gender: json['gender'] as String,
+      phoneNumber: json['phoneNumber'] as String?,
+      linkedinUrl: json['linkedinUrl'] as String?,
+    );
+
+Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
+      'id': instance.id,
+      'firstName': instance.firstName,
+      'lastName': instance.lastName,
+      'role': instance.role,
+      'email': instance.email,
+      'gender': instance.gender,
+      'phoneNumber': instance.phoneNumber,
+      'linkedinUrl': instance.linkedinUrl,
+    };

--- a/lib/user_card.dart
+++ b/lib/user_card.dart
@@ -11,6 +11,7 @@ class UserCard extends StatelessWidget {
   final String email;
   final String? phoneNumber;
   final String? facebookUrl;
+  final String? linkedinUrl;
   final bool isSelected;
   final VoidCallback? onTap;
   final VoidCallback? onEdit;
@@ -27,6 +28,7 @@ class UserCard extends StatelessWidget {
     required this.email,
     this.phoneNumber,
     this.facebookUrl,
+    this.linkedinUrl,
     this.isSelected = false,
     this.onTap,
     this.onEdit,
@@ -114,17 +116,39 @@ class UserCard extends StatelessWidget {
                         ],
                       ),
                     ],
-                    // Facebook button
-                    if (facebookUrl != null && facebookUrl!.isNotEmpty) ...[
+                    // Social media buttons row
+                    if ((facebookUrl != null && facebookUrl!.isNotEmpty) || 
+                        (linkedinUrl != null && linkedinUrl!.isNotEmpty)) ...[
                       const SizedBox(height: 12),
-                      ElevatedButton.icon(
-                        onPressed: () => _launchUrl(facebookUrl!),
-                        icon: const Icon(Icons.facebook, size: 20),
-                        label: const Text('Facebook'),
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: const Color(0xFF1877F2),
-                          foregroundColor: Colors.white,
-                        ),
+                      Row(
+                        children: [
+                          // Facebook button
+                          if (facebookUrl != null && facebookUrl!.isNotEmpty)
+                            ElevatedButton.icon(
+                              onPressed: () => _launchUrl(facebookUrl!),
+                              icon: const Icon(Icons.facebook, size: 20),
+                              label: const Text('Facebook'),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: const Color(0xFF1877F2),
+                                foregroundColor: Colors.white,
+                              ),
+                            ),
+                          // Spacing between buttons
+                          if ((facebookUrl != null && facebookUrl!.isNotEmpty) && 
+                              (linkedinUrl != null && linkedinUrl!.isNotEmpty))
+                            const SizedBox(width: 8),
+                          // LinkedIn button
+                          if (linkedinUrl != null && linkedinUrl!.isNotEmpty)
+                            ElevatedButton.icon(
+                              onPressed: () => _launchUrl(linkedinUrl!),
+                              icon: const Icon(Icons.business, size: 20),
+                              label: const Text('LinkedIn'),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: const Color(0xFF0A66C2),
+                                foregroundColor: Colors.white,
+                              ),
+                            ),
+                        ],
                       ),
                     ],
                   ],


### PR DESCRIPTION
## Frontend Changes

### 1. LinkedIn Button on Profile Card
- Added `linkedinUrl` field to User model (`lib/models/user.dart`)
- Updated JSON serialization code (`lib/models/user.g.dart`)
- Added LinkedIn button to UserCard (`lib/user_card.dart`):
  - Button appears next to Facebook button when LinkedIn URL is present
  - Uses LinkedIn brand color (#0A66C2)
  - Icon: `Icons.business` (Material Design)
  - Opens URL when clicked using `url_launcher`
- Updated main.dart to:
  - Pass `linkedinUrl` from User model to UserCard
  - Add LinkedIn URL input field in Add/Edit User dialog
  - Validate LinkedIn URLs (must contain 'linkedin.com')

### 2. Improved Input Field Padding
- Enhanced padding in Add User dialog for better UX:
  - All TextFormField widgets now have `contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 16)`
  - Added consistent 16px spacing between fields with `SizedBox(height: 16)`
  - Improved touch targets and visual breathing room

### User Experience Improvements
- LinkedIn button only displays when URL is provided
- Social media buttons (Facebook & LinkedIn) are grouped together in a row
- Form validation ensures LinkedIn URLs are valid
- Input fields are more comfortable to interact with on all devices

### Technical Details
- Maintains consistency with existing Facebook button implementation
- Uses existing `url_launcher` package (no new dependencies)
- Follows Material Design guidelines for spacing and padding