### PR TITLE
Add LinkedIn button to profile cards and improve input field padding

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -241,6 +241,7 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
     final roleController = TextEditingController(text: (user?.role ?? ''));
     final emailController = TextEditingController(text: (user?.email ?? ''));
     final phoneController = TextEditingController(text: (user?.phoneNumber ?? ''));
+    final linkedinController = TextEditingController(text: (user?.linkedinUrl ?? ''));
     String gender = (user?.gender ?? 'male');
     final isEdit = user != null;
     final formKey = GlobalKey<FormState>();
@@ -260,27 +261,52 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
                 children: [
                   TextFormField(
                     controller: firstNameController,
-                    decoration: const InputDecoration(labelText: 'First Name', prefixIcon: Icon(Icons.person)),
+                    decoration: const InputDecoration(
+                      labelText: 'First Name',
+                      prefixIcon: Icon(Icons.person),
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    ),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'First name is required' : null,
                   ),
+                  const SizedBox(height: 12),
                   TextFormField(
                     controller: lastNameController,
-                    decoration: const InputDecoration(labelText: 'Last Name', prefixIcon: Icon(Icons.person_outline)),
+                    decoration: const InputDecoration(
+                      labelText: 'Last Name',
+                      prefixIcon: Icon(Icons.person_outline),
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    ),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Last name is required' : null,
                   ),
+                  const SizedBox(height: 12),
                   TextFormField(
                     controller: roleController,
-                    decoration: const InputDecoration(labelText: 'Role', prefixIcon: Icon(Icons.work)),
+                    decoration: const InputDecoration(
+                      labelText: 'Role',
+                      prefixIcon: Icon(Icons.work),
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    ),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Role is required' : null,
                   ),
+                  const SizedBox(height: 12),
                   TextFormField(
                     controller: emailController,
-                    decoration: const InputDecoration(labelText: 'Email', prefixIcon: Icon(Icons.email)),
+                    decoration: const InputDecoration(
+                      labelText: 'Email',
+                      prefixIcon: Icon(Icons.email),
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    ),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Email is required' : null,
                   ),
+                  const SizedBox(height: 12),
                   TextFormField(
                     controller: phoneController,
-                    decoration: const InputDecoration(labelText: 'Phone Number (E.164)', prefixIcon: Icon(Icons.phone), hintText: '+1234567890'),
+                    decoration: const InputDecoration(
+                      labelText: 'Phone Number (E.164)',
+                      prefixIcon: Icon(Icons.phone),
+                      hintText: '+1234567890',
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    ),
                     validator: (value) {
                       if (value == null || value.trim().isEmpty) return null;
                       final cleaned = value.replaceAll(RegExp(r'[\s\-\(\)\[\]]'), '');
@@ -291,9 +317,32 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
                       return null;
                     },
                   ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: linkedinController,
+                    decoration: const InputDecoration(
+                      labelText: 'LinkedIn URL (optional)',
+                      prefixIcon: Icon(Icons.business),
+                      hintText: 'https://www.linkedin.com/in/username',
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    ),
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) return null;
+                      final trimmed = value.trim();
+                      if (!trimmed.startsWith('https://') || !trimmed.contains('linkedin.com')) {
+                        return 'Invalid LinkedIn URL';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 12),
                   DropdownButtonFormField<String>(
                     value: gender,
-                    decoration: const InputDecoration(labelText: 'Gender', prefixIcon: Icon(Icons.wc)),
+                    decoration: const InputDecoration(
+                      labelText: 'Gender',
+                      prefixIcon: Icon(Icons.wc),
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    ),
                     items: ['male', 'female'].map((g) => DropdownMenuItem(value: g, child: Text(g[0].toUpperCase() + g.substring(1)))).toList(),
                     onChanged: (value) => setState(() => gender = value!),
                     validator: (value) => value == null ? 'Gender is required' : null,
@@ -327,8 +376,17 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
       final role = roleController.text.trim();
       final email = emailController.text.trim();
       final phoneNumber = phoneController.text.trim().isEmpty ? null : phoneController.text.trim();
+      final linkedinUrl = linkedinController.text.trim().isEmpty ? null : linkedinController.text.trim();
       try {
-        final body = json.encode({'firstName': firstName, 'lastName': lastName, 'role': role, 'email': email, 'phoneNumber': phoneNumber, 'gender': gender});
+        final body = json.encode({
+          'firstName': firstName,
+          'lastName': lastName,
+          'role': role,
+          'email': email,
+          'phoneNumber': phoneNumber,
+          'linkedinUrl': linkedinUrl,
+          'gender': gender,
+        });
         final url = isEdit ? '${Constants.webServiceBaseUrl}/api/users/${user!.id}' : '${Constants.webServiceBaseUrl}/api/users';
         final method = isEdit ? http.put : http.post;
         final response = await method(
@@ -373,6 +431,7 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
           gender: user.gender,
           email: user.email,
           phoneNumber: user.phoneNumber,
+          linkedinUrl: user.linkedinUrl,
           isSelected: _selectedUserIds.contains(user.id),
           onTap: () {
             setState(() {

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -13,6 +13,7 @@ class User {
   final String email;
   final String gender;
   final String? phoneNumber;
+  final String? linkedinUrl;
 
   User({
     required this.id,
@@ -22,6 +23,7 @@ class User {
     required this.email,
     required this.gender,
     this.phoneNumber,
+    this.linkedinUrl,
   });
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);

--- a/lib/user_card.dart
+++ b/lib/user_card.dart
@@ -11,6 +11,7 @@ class UserCard extends StatelessWidget {
   final String email;
   final String? phoneNumber;
   final String? facebookUrl;
+  final String? linkedinUrl;
   final bool isSelected;
   final VoidCallback? onTap;
   final VoidCallback? onEdit;
@@ -27,6 +28,7 @@ class UserCard extends StatelessWidget {
     required this.email,
     this.phoneNumber,
     this.facebookUrl,
+    this.linkedinUrl,
     this.isSelected = false,
     this.onTap,
     this.onEdit,
@@ -123,6 +125,19 @@ class UserCard extends StatelessWidget {
                         label: const Text('Facebook'),
                         style: ElevatedButton.styleFrom(
                           backgroundColor: const Color(0xFF1877F2),
+                          foregroundColor: Colors.white,
+                        ),
+                      ),
+                    ],
+                    // LinkedIn button
+                    if (linkedinUrl != null && linkedinUrl!.isNotEmpty) ...[
+                      const SizedBox(height: 12),
+                      ElevatedButton.icon(
+                        onPressed: () => _launchUrl(linkedinUrl!),
+                        icon: const Icon(Icons.business, size: 20),
+                        label: const Text('LinkedIn'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFF0A66C2),
                           foregroundColor: Colors.white,
                         ),
                       ),


### PR DESCRIPTION
## Summary
This PR enhances the user profile cards with LinkedIn integration and improves the UX of the Add/Edit User form.

## Changes

### 1. LinkedIn Button Feature
- Added `linkedinUrl` field to `User` model
- Updated `UserCard` widget to display a LinkedIn button when a user has a LinkedIn URL
- LinkedIn button styled with official LinkedIn blue (#0A66C2)
- Button opens LinkedIn profile in external browser using `url_launcher`
- Updated `main.dart` to pass `linkedinUrl` to `UserCard`
- Added LinkedIn URL input field in Add/Edit User dialog with validation

### 2. Input Field Padding Improvements
- Added explicit `contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 12)` to all input fields in the Add/Edit User dialog
- Improved visual spacing and consistency across all form fields
- Added spacing between form fields with `SizedBox(height: 12)`

## UI/UX Improvements
- LinkedIn button only appears when user has a valid LinkedIn URL
- Consistent padding across all input fields for better visual hierarchy
- Form validation ensures LinkedIn URLs are properly formatted (https://linkedin.com)
- Better touch targets and visual spacing in the form

## Testing
- LinkedIn button appears for users with LinkedIn URLs (Alice, Bob, David, Grace)
- LinkedIn button correctly opens external browser
- Form validation works for LinkedIn URL field
- Input fields have improved padding and spacing