### PR TITLE
Add LinkedIn button to profile card and improve input field padding

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -369,7 +369,7 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
           'linkedinUrl': linkedinUrl,
           'gender': gender,
         });
-        final url = isEdit ? '${Constants.webServiceBaseUrl}/api/users/${user!.id}' : '${Constants.webServiceBaseUrl}/api/users';
+        final url = isEdit ? '${Constants.webServiceBaseUrl}/api/users/${user?.id}' : '${Constants.webServiceBaseUrl}/api/users';
         final method = isEdit ? http.put : http.post;
         final response = await method(
           Uri.parse(url),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -241,6 +241,7 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
     final roleController = TextEditingController(text: (user?.role ?? ''));
     final emailController = TextEditingController(text: (user?.email ?? ''));
     final phoneController = TextEditingController(text: (user?.phoneNumber ?? ''));
+    final linkedinController = TextEditingController(text: (user?.linkedinUrl ?? ''));
     String gender = (user?.gender ?? 'male');
     final isEdit = user != null;
     final formKey = GlobalKey<FormState>();
@@ -263,21 +264,25 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
                     decoration: const InputDecoration(labelText: 'First Name', prefixIcon: Icon(Icons.person)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'First name is required' : null,
                   ),
+                  const SizedBox(height: 12),
                   TextFormField(
                     controller: lastNameController,
                     decoration: const InputDecoration(labelText: 'Last Name', prefixIcon: Icon(Icons.person_outline)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Last name is required' : null,
                   ),
+                  const SizedBox(height: 12),
                   TextFormField(
                     controller: roleController,
                     decoration: const InputDecoration(labelText: 'Role', prefixIcon: Icon(Icons.work)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Role is required' : null,
                   ),
+                  const SizedBox(height: 12),
                   TextFormField(
                     controller: emailController,
                     decoration: const InputDecoration(labelText: 'Email', prefixIcon: Icon(Icons.email)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Email is required' : null,
                   ),
+                  const SizedBox(height: 12),
                   TextFormField(
                     controller: phoneController,
                     decoration: const InputDecoration(labelText: 'Phone Number (E.164)', prefixIcon: Icon(Icons.phone), hintText: '+1234567890'),
@@ -291,6 +296,32 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
                       return null;
                     },
                   ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: linkedinController,
+                    decoration: const InputDecoration(
+                      labelText: 'LinkedIn URL (optional)',
+                      prefixIcon: Icon(Icons.business),
+                      hintText: 'https://www.linkedin.com/in/username',
+                    ),
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) return null;
+                      final trimmed = value.trim();
+                      try {
+                        final uri = Uri.parse(trimmed);
+                        if (!uri.host.endsWith('linkedin.com')) {
+                          return 'Must be a LinkedIn URL';
+                        }
+                        if (uri.scheme != 'https') {
+                          return 'Must use HTTPS';
+                        }
+                      } catch (e) {
+                        return 'Invalid URL format';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 12),
                   DropdownButtonFormField<String>(
                     value: gender,
                     decoration: const InputDecoration(labelText: 'Gender', prefixIcon: Icon(Icons.wc)),
@@ -327,8 +358,17 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
       final role = roleController.text.trim();
       final email = emailController.text.trim();
       final phoneNumber = phoneController.text.trim().isEmpty ? null : phoneController.text.trim();
+      final linkedinUrl = linkedinController.text.trim().isEmpty ? null : linkedinController.text.trim();
       try {
-        final body = json.encode({'firstName': firstName, 'lastName': lastName, 'role': role, 'email': email, 'phoneNumber': phoneNumber, 'gender': gender});
+        final body = json.encode({
+          'firstName': firstName,
+          'lastName': lastName,
+          'role': role,
+          'email': email,
+          'phoneNumber': phoneNumber,
+          'linkedinUrl': linkedinUrl,
+          'gender': gender,
+        });
         final url = isEdit ? '${Constants.webServiceBaseUrl}/api/users/${user!.id}' : '${Constants.webServiceBaseUrl}/api/users';
         final method = isEdit ? http.put : http.post;
         final response = await method(
@@ -373,6 +413,7 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
           gender: user.gender,
           email: user.email,
           phoneNumber: user.phoneNumber,
+          linkedinUrl: user.linkedinUrl,
           isSelected: _selectedUserIds.contains(user.id),
           onTap: () {
             setState(() {

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -13,6 +13,7 @@ class User {
   final String email;
   final String gender;
   final String? phoneNumber;
+  final String? linkedinUrl;
 
   User({
     required this.id,
@@ -22,6 +23,7 @@ class User {
     required this.email,
     required this.gender,
     this.phoneNumber,
+    this.linkedinUrl,
   });
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);

--- a/lib/user_card.dart
+++ b/lib/user_card.dart
@@ -11,6 +11,7 @@ class UserCard extends StatelessWidget {
   final String email;
   final String? phoneNumber;
   final String? facebookUrl;
+  final String? linkedinUrl;
   final bool isSelected;
   final VoidCallback? onTap;
   final VoidCallback? onEdit;
@@ -27,6 +28,7 @@ class UserCard extends StatelessWidget {
     required this.email,
     this.phoneNumber,
     this.facebookUrl,
+    this.linkedinUrl,
     this.isSelected = false,
     this.onTap,
     this.onEdit,
@@ -114,17 +116,34 @@ class UserCard extends StatelessWidget {
                         ],
                       ),
                     ],
-                    // Facebook button
-                    if (facebookUrl != null && facebookUrl!.isNotEmpty) ...[
+                    // Social media buttons row
+                    if ((facebookUrl != null && facebookUrl!.isNotEmpty) || (linkedinUrl != null && linkedinUrl!.isNotEmpty)) ...[
                       const SizedBox(height: 12),
-                      ElevatedButton.icon(
-                        onPressed: () => _launchUrl(facebookUrl!),
-                        icon: const Icon(Icons.facebook, size: 20),
-                        label: const Text('Facebook'),
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: const Color(0xFF1877F2),
-                          foregroundColor: Colors.white,
-                        ),
+                      Row(
+                        children: [
+                          if (facebookUrl != null && facebookUrl!.isNotEmpty)
+                            ElevatedButton.icon(
+                              onPressed: () => _launchUrl(facebookUrl!),
+                              icon: const Icon(Icons.facebook, size: 20),
+                              label: const Text('Facebook'),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: const Color(0xFF1877F2),
+                                foregroundColor: Colors.white,
+                              ),
+                            ),
+                          if (facebookUrl != null && facebookUrl!.isNotEmpty && linkedinUrl != null && linkedinUrl!.isNotEmpty)
+                            const SizedBox(width: 8),
+                          if (linkedinUrl != null && linkedinUrl!.isNotEmpty)
+                            ElevatedButton.icon(
+                              onPressed: () => _launchUrl(linkedinUrl!),
+                              icon: const Icon(Icons.business, size: 20),
+                              label: const Text('LinkedIn'),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: const Color(0xFF0A66C2),
+                                foregroundColor: Colors.white,
+                              ),
+                            ),
+                        ],
                       ),
                     ],
                   ],


### PR DESCRIPTION
## Summary
This PR implements two UI improvements:
1. **LinkedIn button on profile cards** - Displays a clickable LinkedIn button when a user has a LinkedIn URL
2. **Improved input field padding** - Adds consistent padding to all input fields in the Add/Edit User dialog

## Changes

### 1. LinkedIn Button Feature
- **lib/models/user.dart**: Added optional `linkedinUrl` field to User model
- **lib/user_card.dart**: 
  - Added `linkedinUrl` parameter to UserCard widget
  - Implemented conditional rendering of LinkedIn button (only shows when URL exists)
  - LinkedIn button uses official brand color (#0A66C2)
  - Button opens LinkedIn profile in external browser
  - Positioned alongside Facebook button in social media row
- **lib/main.dart**:
  - Added LinkedIn URL field to Add/Edit User dialog with validation
  - Validation ensures URLs are from linkedin.com and use HTTPS
  - Passes `linkedinUrl` from User model to UserCard widget

### 2. Input Field Padding Improvement
- **lib/main.dart**: Added `SizedBox(height: 12)` spacing between all input fields in the Add/Edit User dialog
- This improves visual hierarchy and makes the form easier to scan and use

## UI/UX Details
- LinkedIn button only appears when user has a LinkedIn URL (conditional rendering)
- Button uses LinkedIn brand color for consistency
- Input fields now have 12px vertical spacing for better readability
- Form validation ensures LinkedIn URLs are properly formatted

## Testing
- Tested with users who have LinkedIn URLs (Alice, Bob, David)
- Tested with users without LinkedIn URLs (button correctly hidden)
- Validated LinkedIn URL format in Add/Edit dialog
- Verified padding improvements in Add/Edit User form