### PR TITLE
Add LinkedIn button to profile cards and improve input field padding

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -360,7 +360,10 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
           'linkedinUrl': linkedinUrl,
           'gender': gender,
         });
-        final url = isEdit ? '${Constants.webServiceBaseUrl}/api/users/${user!.id}' : '${Constants.webServiceBaseUrl}/api/users';
+        final userId = user?.id;
+        final url = isEdit && userId != null
+            ? '${Constants.webServiceBaseUrl}/api/users/$userId'
+            : '${Constants.webServiceBaseUrl}/api/users';
         final method = isEdit ? http.put : http.post;
         final response = await method(
           Uri.parse(url),
@@ -369,18 +372,24 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
         );
         if (response.statusCode == 200 || response.statusCode == 201) {
           await _fetchUsers();
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(isEdit ? 'User updated' : 'User added')),
-          );
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(isEdit ? 'User updated' : 'User added')),
+            );
+          }
         } else {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Failed to save user')),
-          );
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Failed to save user')),
+            );
+          }
         }
       } catch (e) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error: $e')),
-        );
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Error: $e')),
+          );
+        }
       }
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -241,6 +241,7 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
     final roleController = TextEditingController(text: (user?.role ?? ''));
     final emailController = TextEditingController(text: (user?.email ?? ''));
     final phoneController = TextEditingController(text: (user?.phoneNumber ?? ''));
+    final linkedinController = TextEditingController(text: (user?.linkedinUrl ?? ''));
     String gender = (user?.gender ?? 'male');
     final isEdit = user != null;
     final formKey = GlobalKey<FormState>();
@@ -263,21 +264,25 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
                     decoration: const InputDecoration(labelText: 'First Name', prefixIcon: Icon(Icons.person)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'First name is required' : null,
                   ),
+                  const SizedBox(height: 8),
                   TextFormField(
                     controller: lastNameController,
                     decoration: const InputDecoration(labelText: 'Last Name', prefixIcon: Icon(Icons.person_outline)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Last name is required' : null,
                   ),
+                  const SizedBox(height: 8),
                   TextFormField(
                     controller: roleController,
                     decoration: const InputDecoration(labelText: 'Role', prefixIcon: Icon(Icons.work)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Role is required' : null,
                   ),
+                  const SizedBox(height: 8),
                   TextFormField(
                     controller: emailController,
                     decoration: const InputDecoration(labelText: 'Email', prefixIcon: Icon(Icons.email)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Email is required' : null,
                   ),
+                  const SizedBox(height: 8),
                   TextFormField(
                     controller: phoneController,
                     decoration: const InputDecoration(labelText: 'Phone Number (E.164)', prefixIcon: Icon(Icons.phone), hintText: '+1234567890'),
@@ -291,6 +296,23 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
                       return null;
                     },
                   ),
+                  const SizedBox(height: 8),
+                  TextFormField(
+                    controller: linkedinController,
+                    decoration: const InputDecoration(labelText: 'LinkedIn URL (optional)', prefixIcon: Icon(Icons.link), hintText: 'https://linkedin.com/in/username'),
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) return null;
+                      final trimmed = value.trim();
+                      if (!trimmed.startsWith('http://') && !trimmed.startsWith('https://')) {
+                        return 'URL must start with http:// or https://';
+                      }
+                      if (!trimmed.toLowerCase().contains('linkedin.com')) {
+                        return 'Must be a LinkedIn URL';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 8),
                   DropdownButtonFormField<String>(
                     value: gender,
                     decoration: const InputDecoration(labelText: 'Gender', prefixIcon: Icon(Icons.wc)),
@@ -327,8 +349,17 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
       final role = roleController.text.trim();
       final email = emailController.text.trim();
       final phoneNumber = phoneController.text.trim().isEmpty ? null : phoneController.text.trim();
+      final linkedinUrl = linkedinController.text.trim().isEmpty ? null : linkedinController.text.trim();
       try {
-        final body = json.encode({'firstName': firstName, 'lastName': lastName, 'role': role, 'email': email, 'phoneNumber': phoneNumber, 'gender': gender});
+        final body = json.encode({
+          'firstName': firstName,
+          'lastName': lastName,
+          'role': role,
+          'email': email,
+          'phoneNumber': phoneNumber,
+          'linkedinUrl': linkedinUrl,
+          'gender': gender,
+        });
         final url = isEdit ? '${Constants.webServiceBaseUrl}/api/users/${user!.id}' : '${Constants.webServiceBaseUrl}/api/users';
         final method = isEdit ? http.put : http.post;
         final response = await method(
@@ -373,6 +404,7 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
           gender: user.gender,
           email: user.email,
           phoneNumber: user.phoneNumber,
+          linkedinUrl: user.linkedinUrl,
           isSelected: _selectedUserIds.contains(user.id),
           onTap: () {
             setState(() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -244,6 +244,7 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
     final linkedinController = TextEditingController(text: user?.linkedinUrl ?? '');
     String gender = user?.gender ?? 'male';
     final isEdit = user != null;
+    final int? userId = user?.id;
     final formKey = GlobalKey<FormState>();
     bool isLoading = false;
 
@@ -360,7 +361,6 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
           'linkedinUrl': linkedinUrl,
           'gender': gender,
         });
-        final userId = user?.id;
         final url = isEdit && userId != null
             ? '${Constants.webServiceBaseUrl}/api/users/$userId'
             : '${Constants.webServiceBaseUrl}/api/users';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -236,13 +236,13 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
   }
 
   Future<void> _showUserDialog({User? user}) async {
-    final firstNameController = TextEditingController(text: (user?.firstName ?? ''));
-    final lastNameController = TextEditingController(text: (user?.lastName ?? ''));
-    final roleController = TextEditingController(text: (user?.role ?? ''));
-    final emailController = TextEditingController(text: (user?.email ?? ''));
-    final phoneController = TextEditingController(text: (user?.phoneNumber ?? ''));
-    final linkedinController = TextEditingController(text: (user?.linkedinUrl ?? ''));
-    String gender = (user?.gender ?? 'male');
+    final firstNameController = TextEditingController(text: user?.firstName ?? '');
+    final lastNameController = TextEditingController(text: user?.lastName ?? '');
+    final roleController = TextEditingController(text: user?.role ?? '');
+    final emailController = TextEditingController(text: user?.email ?? '');
+    final phoneController = TextEditingController(text: user?.phoneNumber ?? '');
+    final linkedinController = TextEditingController(text: user?.linkedinUrl ?? '');
+    String gender = user?.gender ?? 'male';
     final isEdit = user != null;
     final formKey = GlobalKey<FormState>();
     bool isLoading = false;

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -13,6 +13,7 @@ class User {
   final String email;
   final String gender;
   final String? phoneNumber;
+  final String? linkedinUrl;
 
   User({
     required this.id,
@@ -22,6 +23,7 @@ class User {
     required this.email,
     required this.gender,
     this.phoneNumber,
+    this.linkedinUrl,
   });
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);

--- a/lib/user_card.dart
+++ b/lib/user_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 class UserCard extends StatelessWidget {
   final String firstName;
@@ -11,6 +12,7 @@ class UserCard extends StatelessWidget {
   final String email;
   final String? phoneNumber;
   final String? facebookUrl;
+  final String? linkedinUrl;
   final bool isSelected;
   final VoidCallback? onTap;
   final VoidCallback? onEdit;
@@ -27,6 +29,7 @@ class UserCard extends StatelessWidget {
     required this.email,
     this.phoneNumber,
     this.facebookUrl,
+    this.linkedinUrl,
     this.isSelected = false,
     this.onTap,
     this.onEdit,
@@ -114,17 +117,29 @@ class UserCard extends StatelessWidget {
                         ],
                       ),
                     ],
-                    // Facebook button
-                    if (facebookUrl != null && facebookUrl!.isNotEmpty) ...[
+                    // Social media buttons row
+                    if ((facebookUrl != null && facebookUrl!.isNotEmpty) || (linkedinUrl != null && linkedinUrl!.isNotEmpty)) ...[
                       const SizedBox(height: 12),
-                      ElevatedButton.icon(
-                        onPressed: () => _launchUrl(facebookUrl!),
-                        icon: const Icon(Icons.facebook, size: 20),
-                        label: const Text('Facebook'),
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: const Color(0xFF1877F2),
-                          foregroundColor: Colors.white,
-                        ),
+                      Row(
+                        children: [
+                          if (linkedinUrl != null && linkedinUrl!.isNotEmpty)
+                            Padding(
+                              padding: const EdgeInsets.only(right: 8),
+                              child: _SocialButton(
+                                icon: FontAwesomeIcons.linkedin,
+                                color: const Color(0xFF0A66C2),
+                                label: 'LinkedIn',
+                                onTap: () => _launchUrl(linkedinUrl!),
+                              ),
+                            ),
+                          if (facebookUrl != null && facebookUrl!.isNotEmpty)
+                            _SocialButton(
+                              icon: Icons.facebook,
+                              color: const Color(0xFF1877F2),
+                              label: 'Facebook',
+                              onTap: () => _launchUrl(facebookUrl!),
+                            ),
+                        ],
                       ),
                     ],
                   ],
@@ -226,6 +241,35 @@ class _CallButton extends StatelessWidget {
           height: 40,
           child: Icon(icon, color: color, size: 20),
         ),
+      ),
+    );
+  }
+}
+
+class _SocialButton extends StatelessWidget {
+  final IconData icon;
+  final Color color;
+  final String label;
+  final VoidCallback onTap;
+
+  const _SocialButton({
+    required this.icon,
+    required this.color,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton.icon(
+      onPressed: onTap,
+      icon: Icon(icon, size: 18),
+      label: Text(label),
+      style: ElevatedButton.styleFrom(
+        backgroundColor: color,
+        foregroundColor: Colors.white,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        minimumSize: const Size(0, 36),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,7 @@
+---
 name: cool_app_fe
 description: "Coolest app ever made. This is the Flutter frontend of it"
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: 'none'  # Remove this line if you wish to publish to pub.dev
 
 version: 1.0.0+1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   http: ^1.6.0
   provider: ^6.1.5+1
   url_launcher: ^6.3.0
+  font_awesome_flutter: ^10.6.0
 
   # Required for json_serializable
   json_annotation: ^4.9.0


### PR DESCRIPTION
## Changes

### Frontend (cool_app_fe)

#### 1. LinkedIn Button Feature
- Added `font_awesome_flutter: ^10.6.0` dependency for LinkedIn icon
- Updated `User` model to include optional `linkedinUrl` field
- Modified `UserCard` component to display LinkedIn button when URL is available
- LinkedIn button uses official LinkedIn blue color (#0A66C2)
- Button opens LinkedIn profile in browser using `url_launcher`
- Refactored social media buttons (Facebook + LinkedIn) into a unified row layout
- Created reusable `_SocialButton` widget for consistent styling

#### 2. Input Field Padding Improvement
- Updated `app_theme.dart` to include consistent padding for all input fields
- Applied `contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 14)` to both light and dark themes
- This padding is now automatically applied to all `TextFormField` widgets throughout the app

#### 3. Add/Edit User Dialog Enhancement
- Added LinkedIn URL input field to the user dialog
- Added validation to ensure LinkedIn URLs are properly formatted
- Added spacing between form fields for better visual hierarchy (8px gaps)
- LinkedIn field is optional and validates URL format and domain

### UI/UX Improvements
- Better visual spacing in forms with consistent 8px gaps between fields
- Improved touch targets and readability with proper input padding
- Professional LinkedIn integration matching brand colors
- Responsive layout that adapts to available space

## Testing
- Verify LinkedIn button appears only for users with LinkedIn URLs (Alice, Bob, David, Grace)
- Test clicking LinkedIn button opens correct profile
- Verify input fields have proper padding in Add User dialog
- Test adding/editing users with LinkedIn URLs
- Verify validation works for invalid LinkedIn URLs
- Test both light and dark themes