### PR TITLE
Enhance user profile cards with LinkedIn button and improve Add User dialog spacing

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -241,6 +241,7 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
     final roleController = TextEditingController(text: (user?.role ?? ''));
     final emailController = TextEditingController(text: (user?.email ?? ''));
     final phoneController = TextEditingController(text: (user?.phoneNumber ?? ''));
+    final linkedinController = TextEditingController(text: (user?.linkedinUrl ?? ''));
     String gender = (user?.gender ?? 'male');
     final isEdit = user != null;
     final formKey = GlobalKey<FormState>();
@@ -263,34 +264,44 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
                     decoration: const InputDecoration(labelText: 'First Name', prefixIcon: Icon(Icons.person)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'First name is required' : null,
                   ),
+                  const SizedBox(height: 8),
                   TextFormField(
                     controller: lastNameController,
                     decoration: const InputDecoration(labelText: 'Last Name', prefixIcon: Icon(Icons.person_outline)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Last name is required' : null,
                   ),
+                  const SizedBox(height: 8),
                   TextFormField(
                     controller: roleController,
                     decoration: const InputDecoration(labelText: 'Role', prefixIcon: Icon(Icons.work)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Role is required' : null,
                   ),
+                  const SizedBox(height: 8),
                   TextFormField(
                     controller: emailController,
                     decoration: const InputDecoration(labelText: 'Email', prefixIcon: Icon(Icons.email)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Email is required' : null,
                   ),
+                  const SizedBox(height: 8),
                   TextFormField(
                     controller: phoneController,
                     decoration: const InputDecoration(labelText: 'Phone Number (E.164)', prefixIcon: Icon(Icons.phone), hintText: '+1234567890'),
                     validator: (value) {
                       if (value == null || value.trim().isEmpty) return null;
                       final cleaned = value.replaceAll(RegExp(r'[\s\-\(\)\[\]]'), '');
-                      final regex = RegExp(r'^\+?[1-9]\d{6,14}$');
+                      final regex = RegExp(r'^\+?[1-9]\d{6,14}\$');
                       if (!regex.hasMatch(cleaned)) {
                         return 'Invalid phone format';
                       }
                       return null;
                     },
                   ),
+                  const SizedBox(height: 8),
+                  TextFormField(
+                    controller: linkedinController,
+                    decoration: const InputDecoration(labelText: 'LinkedIn URL', prefixIcon: Icon(Icons.business), hintText: 'https://linkedin.com/in/username'),
+                  ),
+                  const SizedBox(height: 8),
                   DropdownButtonFormField<String>(
                     value: gender,
                     decoration: const InputDecoration(labelText: 'Gender', prefixIcon: Icon(Icons.wc)),
@@ -327,8 +338,9 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
       final role = roleController.text.trim();
       final email = emailController.text.trim();
       final phoneNumber = phoneController.text.trim().isEmpty ? null : phoneController.text.trim();
+      final linkedinUrl = linkedinController.text.trim().isEmpty ? null : linkedinController.text.trim();
       try {
-        final body = json.encode({'firstName': firstName, 'lastName': lastName, 'role': role, 'email': email, 'phoneNumber': phoneNumber, 'gender': gender});
+        final body = json.encode({'firstName': firstName, 'lastName': lastName, 'role': role, 'email': email, 'phoneNumber': phoneNumber, 'linkedinUrl': linkedinUrl, 'gender': gender});
         final url = isEdit ? '${Constants.webServiceBaseUrl}/api/users/${user!.id}' : '${Constants.webServiceBaseUrl}/api/users';
         final method = isEdit ? http.put : http.post;
         final response = await method(
@@ -373,6 +385,8 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
           gender: user.gender,
           email: user.email,
           phoneNumber: user.phoneNumber,
+          facebookUrl: null, // Assuming no facebook for now
+          linkedinUrl: user.linkedinUrl,
           isSelected: _selectedUserIds.contains(user.id),
           onTap: () {
             setState(() {

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -13,6 +13,7 @@ class User {
   final String email;
   final String gender;
   final String? phoneNumber;
+  final String? linkedinUrl;
 
   User({
     required this.id,
@@ -22,6 +23,7 @@ class User {
     required this.email,
     required this.gender,
     this.phoneNumber,
+    this.linkedinUrl,
   });
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);

--- a/lib/user_card.dart
+++ b/lib/user_card.dart
@@ -11,6 +11,7 @@ class UserCard extends StatelessWidget {
   final String email;
   final String? phoneNumber;
   final String? facebookUrl;
+  final String? linkedinUrl;
   final bool isSelected;
   final VoidCallback? onTap;
   final VoidCallback? onEdit;
@@ -27,6 +28,7 @@ class UserCard extends StatelessWidget {
     required this.email,
     this.phoneNumber,
     this.facebookUrl,
+    this.linkedinUrl,
     this.isSelected = false,
     this.onTap,
     this.onEdit,
@@ -123,6 +125,19 @@ class UserCard extends StatelessWidget {
                         label: const Text('Facebook'),
                         style: ElevatedButton.styleFrom(
                           backgroundColor: const Color(0xFF1877F2),
+                          foregroundColor: Colors.white,
+                        ),
+                      ),
+                    ],
+                    // LinkedIn button
+                    if (linkedinUrl != null && linkedinUrl!.isNotEmpty) ...[
+                      const SizedBox(height: 12),
+                      ElevatedButton.icon(
+                        onPressed: () => _launchUrl(linkedinUrl!),
+                        icon: const Icon(Icons.business, size: 20),
+                        label: const Text('LinkedIn'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFF0077B5),
                           foregroundColor: Colors.white,
                         ),
                       ),


### PR DESCRIPTION
This PR adds LinkedIn support to user profiles and improves the Add User dialog UX.

### Changes:
- **User Model**: Added `linkedinUrl` field with JSON serialization support.
- **UserCard Widget**: Added `linkedinUrl` prop and rendered a LinkedIn button similar to the Facebook button, using LinkedIn's brand color (#0077B5).
- **Add User Dialog**: Added input field for LinkedIn URL and added padding (8px) between all input fields for better spacing.
- **API Integration**: Updated the dialog to send `linkedinUrl` in the create/update user requests.

The LinkedIn button will only appear if the user has a LinkedIn URL set. Users can now add/edit LinkedIn profiles through the Add/Edit User dialog.