### PR TITLE
Add LinkedIn button to profile cards and improve Add User dialog spacing

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -241,6 +241,7 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
     final roleController = TextEditingController(text: (user?.role ?? ''));
     final emailController = TextEditingController(text: (user?.email ?? ''));
     final phoneController = TextEditingController(text: (user?.phoneNumber ?? ''));
+    final linkedinController = TextEditingController(text: (user?.linkedinUrl ?? ''));
     String gender = (user?.gender ?? 'male');
     final isEdit = user != null;
     final formKey = GlobalKey<FormState>();
@@ -263,21 +264,25 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
                     decoration: const InputDecoration(labelText: 'First Name', prefixIcon: Icon(Icons.person)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'First name is required' : null,
                   ),
+                  const SizedBox(height: 12),
                   TextFormField(
                     controller: lastNameController,
                     decoration: const InputDecoration(labelText: 'Last Name', prefixIcon: Icon(Icons.person_outline)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Last name is required' : null,
                   ),
+                  const SizedBox(height: 12),
                   TextFormField(
                     controller: roleController,
                     decoration: const InputDecoration(labelText: 'Role', prefixIcon: Icon(Icons.work)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Role is required' : null,
                   ),
+                  const SizedBox(height: 12),
                   TextFormField(
                     controller: emailController,
                     decoration: const InputDecoration(labelText: 'Email', prefixIcon: Icon(Icons.email)),
                     validator: (value) => value?.trim().isEmpty ?? true ? 'Email is required' : null,
                   ),
+                  const SizedBox(height: 12),
                   TextFormField(
                     controller: phoneController,
                     decoration: const InputDecoration(labelText: 'Phone Number (E.164)', prefixIcon: Icon(Icons.phone), hintText: '+1234567890'),
@@ -291,6 +296,12 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
                       return null;
                     },
                   ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: linkedinController,
+                    decoration: const InputDecoration(labelText: 'LinkedIn URL', prefixIcon: Icon(Icons.link)),
+                  ),
+                  const SizedBox(height: 12),
                   DropdownButtonFormField<String>(
                     value: gender,
                     decoration: const InputDecoration(labelText: 'Gender', prefixIcon: Icon(Icons.wc)),
@@ -327,8 +338,9 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
       final role = roleController.text.trim();
       final email = emailController.text.trim();
       final phoneNumber = phoneController.text.trim().isEmpty ? null : phoneController.text.trim();
+      final linkedinUrl = linkedinController.text.trim().isEmpty ? null : linkedinController.text.trim();
       try {
-        final body = json.encode({'firstName': firstName, 'lastName': lastName, 'role': role, 'email': email, 'phoneNumber': phoneNumber, 'gender': gender});
+        final body = json.encode({'firstName': firstName, 'lastName': lastName, 'role': role, 'email': email, 'phoneNumber': phoneNumber, 'linkedinUrl': linkedinUrl, 'gender': gender});
         final url = isEdit ? '${Constants.webServiceBaseUrl}/api/users/${user!.id}' : '${Constants.webServiceBaseUrl}/api/users';
         final method = isEdit ? http.put : http.post;
         final response = await method(
@@ -373,6 +385,8 @@ class _MyHomePageState extends State<MyHomePage> with FilterSortMixin<User> {
           gender: user.gender,
           email: user.email,
           phoneNumber: user.phoneNumber,
+          facebookUrl: null, // Assuming no facebookUrl in User model
+          linkedinUrl: user.linkedinUrl,
           isSelected: _selectedUserIds.contains(user.id),
           onTap: () {
             setState(() {

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -13,6 +13,8 @@ class User {
   final String email;
   final String gender;
   final String? phoneNumber;
+  @JsonKey(name: 'linkedinUrl')
+  final String? linkedinUrl;
 
   User({
     required this.id,
@@ -22,6 +24,7 @@ class User {
     required this.email,
     required this.gender,
     this.phoneNumber,
+    this.linkedinUrl,
   });
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);

--- a/lib/user_card.dart
+++ b/lib/user_card.dart
@@ -11,6 +11,7 @@ class UserCard extends StatelessWidget {
   final String email;
   final String? phoneNumber;
   final String? facebookUrl;
+  final String? linkedinUrl;
   final bool isSelected;
   final VoidCallback? onTap;
   final VoidCallback? onEdit;
@@ -27,6 +28,7 @@ class UserCard extends StatelessWidget {
     required this.email,
     this.phoneNumber,
     this.facebookUrl,
+    this.linkedinUrl,
     this.isSelected = false,
     this.onTap,
     this.onEdit,
@@ -123,6 +125,19 @@ class UserCard extends StatelessWidget {
                         label: const Text('Facebook'),
                         style: ElevatedButton.styleFrom(
                           backgroundColor: const Color(0xFF1877F2),
+                          foregroundColor: Colors.white,
+                        ),
+                      ),
+                    ],
+                    // LinkedIn button
+                    if (linkedinUrl != null && linkedinUrl!.isNotEmpty) ...[
+                      const SizedBox(height: 12),
+                      ElevatedButton.icon(
+                        onPressed: () => _launchUrl(linkedinUrl!),
+                        icon: const Icon(Icons.business, size: 20),
+                        label: const Text('LinkedIn'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFF0077B5),
                           foregroundColor: Colors.white,
                         ),
                       ),


### PR DESCRIPTION
This PR adds the following frontend enhancements:

- Added optional `linkedinUrl` field to the User model with proper JSON annotation.
- Implemented LinkedIn button in UserCard widget, similar to the existing Facebook button, using the LinkedIn brand color.
- Added LinkedIn URL input field to the Add/Edit User dialog.
- Increased padding between input fields in the Add User dialog for better UX.
- Updated UserCard instantiation to pass the linkedinUrl from the User model.

These changes support the backend updates for linkedinUrl and improve the user interface.